### PR TITLE
fixed ARM uname regexp for QEMU image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MAN1DIR=${prefix}/man/man1
 
 EXTRACFLAGS=
 
-MYARCH:=$(shell uname -m | sed -e 's/i[4-9]86/i386/' -e 's/armv[3-7]t\?[eh]\?[lb]/arm/')
+MYARCH:=$(shell uname -m | sed -e 's/i[4-9]86/i386/' -e 's/armv[3-7]t\?[eh]\?j\?[lb]/arm/')
 
 # This extra-ugly cruft is here so make will not run uname and sed each
 # time it looks at $(OBJDIR).  This alone sped up running make when


### PR DESCRIPTION
I needed this change to get dietlibc building cleanly on my Debian Wheezy ARM image (uname -m gives "armv5tejl").
